### PR TITLE
Fix spatial and temporal frequency grid generation in speed tuning

### DIFF
--- a/+ndi/+calc/+vis/speed_tuning.m
+++ b/+ndi/+calc/+vis/speed_tuning.m
@@ -278,8 +278,8 @@ classdef speed_tuning < ndi.calc.tuning_fit
             significance = struct('visual_response_anova_p', anova_across_stims_blank, ...
                 'across_stimuli_anova_p', anova_across_stims);
 
-            sfs = logspace(0.01, 60, 200);
-            tfs = logspace(0.01, 120, 200);
+            sfs = logspace(log10(0.01), log10(60),  14);
+            tfs = logspace(log10(0.01), log10(120), 14);
             [SFs, TFs] = meshgrid(sfs, tfs);
 
             %add fit with speed parameter set to 0


### PR DESCRIPTION
## Summary
Corrected the spatial and temporal frequency grid generation in the speed tuning visualization module to use proper logarithmic spacing with explicit base-10 logarithm conversion.

## Key Changes
- Updated `sfs` (spatial frequencies) generation from `logspace(0.01, 60, 200)` to `logspace(log10(0.01), log10(60), 14)`
- Updated `tfs` (temporal frequencies) generation from `logspace(0.01, 120, 200)` to `logspace(log10(0.01), log10(120), 14)`
- Reduced grid resolution from 200 points to 14 points per dimension
- Explicitly converted frequency range endpoints to log10 scale for clarity and correctness

## Implementation Details
The original code incorrectly passed linear values (0.01, 60, 120) directly to `logspace()`, which expects logarithmic exponents. The fix properly converts the frequency bounds using `log10()` before passing them to `logspace()`, ensuring the generated grids span the intended frequency ranges in logarithmic space. The reduction in grid points (200 → 14) likely reflects a performance optimization or adjustment to computational requirements for the fitting procedure.

https://claude.ai/code/session_01Eg1wMcD5HPSZ9hcMaTCMMK