### PR TITLE
Scale optimization bounds by log(10) for tuningfunc compatibility

### DIFF
--- a/+vis/+speed/fit.m
+++ b/+vis/+speed/fit.m
@@ -43,9 +43,12 @@ function [P, sse, r_squared] = fit(SF, TF, R, min_xi, max_xi, options)
     SF = SF(:); TF = TF(:); R = R(:); % Ensure column vectors
 
     % --- Multi-start Optimization Setup ---
-    % Define hard constraints (upper and lower bounds) for the fit parameters
-    Upper = [2 * max(R); 3; max_xi; 4; 4; max(SF); max(TF)];
-    Lower = [0; -3; min_xi; 0.1; 0.1; min(SF); min(TF)];
+    % Define hard constraints (upper and lower bounds) for the fit parameters.
+    % sigma_sf, sigma_tf, and zeta are scaled by log(10) so that the search
+    % space matches the prior natural-log formulation now that tuningfunc
+    % uses log10.
+    Upper = [2 * max(R); 3 * log(10); max_xi; 4 / log(10); 4 / log(10); max(SF); max(TF)];
+    Lower = [0; -3 * log(10); min_xi; 0.1 / log(10); 0.1 / log(10); min(SF); min(TF)];
 
     StartPoint = zeros(7, options.numberStartPoints);
 

--- a/+vis/+speed/fit_fullspeed.m
+++ b/+vis/+speed/fit_fullspeed.m
@@ -40,9 +40,12 @@ function [parameters, sse, r_squared] = fit_fullspeed(sf, tf, r, options)
     sf = sf(:); tf = tf(:); r = r(:); % Ensure column vectors
 
     % --- Multi-start Optimization Setup ---
-    % Define hard constraints, identical to vis.speed.fit but with xi fixed at 1
-    Upper = [2 * max(r); 3; 1; 4; 4; max(sf); max(tf)];
-    Lower = [0; -3; 1; 0.1; 0.1; min(sf); min(tf)];
+    % Define hard constraints, identical to vis.speed.fit but with xi fixed at 1.
+    % sigma_sf, sigma_tf, and zeta are scaled by log(10) so that the search
+    % space matches the prior natural-log formulation now that tuningfunc
+    % uses log10.
+    Upper = [2 * max(r); 3 * log(10); 1; 4 / log(10); 4 / log(10); max(sf); max(tf)];
+    Lower = [0; -3 * log(10); 1; 0.1 / log(10); 0.1 / log(10); min(sf); min(tf)];
 
     StartPoint = zeros(7, options.numberStartPoints);
 

--- a/+vis/+speed/fit_nospeed.m
+++ b/+vis/+speed/fit_nospeed.m
@@ -40,9 +40,12 @@ function [parameters, sse, r_squared] = fit_nospeed(sf, tf, r, options)
     sf = sf(:); tf = tf(:); r = r(:); % Ensure column vectors
 
     % --- Multi-start Optimization Setup ---
-    % Define hard constraints, identical to vis.speed.fit but with xi fixed at 0
-    Upper = [2 * max(r); 3; 0; 4; 4; max(sf); max(tf)];
-    Lower = [0; -3; 0; 0.1; 0.1; min(sf); min(tf)];
+    % Define hard constraints, identical to vis.speed.fit but with xi fixed at 0.
+    % sigma_sf, sigma_tf, and zeta are scaled by log(10) so that the search
+    % space matches the prior natural-log formulation now that tuningfunc
+    % uses log10.
+    Upper = [2 * max(r); 3 * log(10); 0; 4 / log(10); 4 / log(10); max(sf); max(tf)];
+    Lower = [0; -3 * log(10); 0; 0.1 / log(10); 0.1 / log(10); min(sf); min(tf)];
 
     StartPoint = zeros(7, options.numberStartPoints);
 


### PR DESCRIPTION
## Summary
Updated the optimization parameter bounds in three fitting functions to account for a change in `tuningfunc` that now uses log10 scaling. The bounds for `sigma_sf`, `sigma_tf`, and `zeta` parameters are now scaled by `log(10)` to maintain consistency with the natural-log formulation of the prior.

## Key Changes
- **fit.m**: Scaled upper and lower bounds for parameters 2, 4, and 5 (sigma_sf, zeta, sigma_tf) by multiplying/dividing by `log(10)`
- **fit_fullspeed.m**: Applied identical scaling adjustments as fit.m, with xi fixed at 1
- **fit_nospeed.m**: Applied identical scaling adjustments as fit.m, with xi fixed at 0

## Implementation Details
- Parameter bounds are adjusted as follows:
  - `sigma_sf` (param 2): `3` → `3 * log(10)` and `-3` → `-3 * log(10)`
  - `zeta` (param 4): `4` → `4 / log(10)` and `0.1` → `0.1 / log(10)`
  - `sigma_tf` (param 5): `4` → `4 / log(10)` and `0.1` → `0.1 / log(10)`
- Updated comments in all three files to document the scaling rationale
- No changes to the optimization logic itself, only the constraint bounds

https://claude.ai/code/session_01Je3EGYVpUYUxfyYjmhTfgn