### PR TITLE
Add vis.speed.halfpeakcontour for half-peak contour computation

### DIFF
--- a/+vis/+speed/halfpeakcontour.m
+++ b/+vis/+speed/halfpeakcontour.m
@@ -1,0 +1,129 @@
+function [X, Y, peak_sf, peak_tf] = halfpeakcontour(P, options)
+% HALFPEAKCONTOUR - Compute the half-peak contour of a speed tuning function
+%
+%   [X, Y] = vis.speed.halfpeakcontour(P)
+%   [X, Y, PEAK_SF, PEAK_TF] = vis.speed.halfpeakcontour(P, ...)
+%
+%   Given a set of parameters P for a speed tuning function (see
+%   vis.speed.tuningfunc), compute the coordinates of the contour at which
+%   the response falls to half of its peak value (the half-peak, or
+%   half-maximum, contour) surrounding the preferred spatial and temporal
+%   frequency.
+%
+%   The contour is computed by sweeping rays outward from the peak in
+%   log10(SF)/log10(TF) space, which is the space in which the tuning
+%   function is naturally symmetric. One point is returned for each whole
+%   degree of angle, so X and Y are 360x1 column vectors. X contains the
+%   spatial frequency (cycles/degree) coordinates and Y contains the
+%   temporal frequency (Hz) coordinates of the contour.
+%
+%   Inputs:
+%     P  - A 7-element parameter vector [A, zeta, xi, sigma_sf, sigma_tf,
+%          sf0, tf0] as used by vis.speed.tuningfunc.
+%
+%   Name-Value Pair Arguments:
+%     MaxRadius  - The maximum distance (in log10 units) to search outward
+%                  from the peak along each ray. (Default: 10)
+%     RadiusStep - The step size (in log10 units) used when searching for
+%                  the half-peak crossing along each ray. (Default: 1e-3)
+%
+%   Outputs:
+%     X        - 360x1 vector of spatial frequency coordinates (c/deg).
+%     Y        - 360x1 vector of temporal frequency coordinates (Hz).
+%     PEAK_SF  - The preferred spatial frequency (cycles/degree), equal to
+%                the sf0 parameter, P(6).
+%     PEAK_TF  - The preferred temporal frequency (Hz), equal to the tf0
+%                parameter, P(7).
+%
+%   The i-th point (X(i),Y(i)) lies along the ray at angle (i-1) degrees,
+%   measured counter-clockwise in log10(SF)/log10(TF) space, where 0 degrees
+%   points toward increasing spatial frequency. If the response never falls
+%   to half its peak along a ray within MaxRadius, the corresponding
+%   coordinates are returned as NaN.
+%
+%   Example:
+%     P = [10, 0, 0, 0.5, 0.5, 0.1, 4]; % A simple symmetric tuning curve
+%     [X, Y] = vis.speed.halfpeakcontour(P);
+%     figure;
+%     loglog(X, Y, 'k-'); hold on;
+%     loglog(P(6), P(7), 'r+'); % mark the peak
+%     xlabel('Spatial frequency (c/deg)');
+%     ylabel('Temporal frequency (Hz)');
+%
+%   See also: vis.speed.tuningfunc, vis.speed.plottuning
+%
+
+    arguments
+        P (1,:) double {mustBeReal}
+        options.MaxRadius (1,1) double {mustBePositive} = 10
+        options.RadiusStep (1,1) double {mustBePositive} = 1e-3
+    end
+
+    if numel(P) ~= 7
+        error('vis:speed:halfpeakcontour:badParameters', ...
+            'P must be a 7-element parameter vector [A zeta xi sigma_sf sigma_tf sf0 tf0].');
+    end
+
+    peak_sf = P(6); % sf0, the preferred spatial frequency
+    peak_tf = P(7); % tf0, the preferred temporal frequency
+
+    if peak_sf <= 0 || peak_tf <= 0
+        error('vis:speed:halfpeakcontour:badPeak', ...
+            'The preferred frequencies sf0 (P(6)) and tf0 (P(7)) must be positive.');
+    end
+
+    % Work in log10 space, where the tuning function is naturally symmetric.
+    center = [log10(peak_sf), log10(peak_tf)];
+
+    % The peak response is attained at (sf0, tf0).
+    peak_response = vis.speed.tuningfunc(peak_sf, peak_tf, P);
+    half_response = peak_response / 2;
+
+    % Set up the radial search grid (shared across all directions).
+    r = (0:options.RadiusStep:options.MaxRadius).';
+    nAngles = 360;
+
+    X = nan(nAngles, 1);
+    Y = nan(nAngles, 1);
+
+    if ~(peak_response > 0)
+        % A non-positive peak has no meaningful half-peak contour.
+        return;
+    end
+
+    for i = 1:nAngles
+        theta = (i - 1) * pi / 180; % angle in radians, one point per degree
+        dir = [cos(theta), sin(theta)];
+
+        % Coordinates along this ray in log10 space.
+        logSF = center(1) + r * dir(1);
+        logTF = center(2) + r * dir(2);
+
+        Rvals = vis.speed.tuningfunc(10.^logSF, 10.^logTF, P);
+
+        % Find the first point along the ray at or below the half-peak level.
+        below = find(Rvals <= half_response, 1, 'first');
+
+        if isempty(below) || below == 1
+            % No crossing found (or the peak itself is already <= half): leave NaN.
+            continue;
+        end
+
+        % Linearly interpolate (in radius) between the bracketing samples to
+        % refine the location of the half-peak crossing.
+        rLow = r(below - 1);
+        rHigh = r(below);
+        Rlow = Rvals(below - 1);
+        Rhigh = Rvals(below);
+
+        if Rhigh == Rlow
+            rCross = rHigh;
+        else
+            rCross = rLow + (half_response - Rlow) * (rHigh - rLow) / (Rhigh - Rlow);
+        end
+
+        X(i) = 10.^(center(1) + rCross * dir(1));
+        Y(i) = 10.^(center(2) + rCross * dir(2));
+    end
+
+end

--- a/tests/+vis/+speed/test_halfpeakcontour.m
+++ b/tests/+vis/+speed/test_halfpeakcontour.m
@@ -1,0 +1,135 @@
+classdef test_halfpeakcontour < matlab.unittest.TestCase
+% TEST_HALFPEAKCONTOUR - Unit tests for vis.speed.halfpeakcontour
+
+    methods (Test)
+
+        function testOutputSizeAndPeak(testCase)
+            % The contour must contain exactly 360 points (one per degree)
+            % and report the peak at sf0/tf0.
+
+            % P = [A, zeta, xi, sigma_sf, sigma_tf, sf0, tf0]
+            P = [10, 0, 0, 0.5, 0.5, 0.1, 4];
+
+            [X, Y, peak_sf, peak_tf] = vis.speed.halfpeakcontour(P);
+
+            testCase.verifySize(X, [360 1], 'X must be a 360x1 column vector.');
+            testCase.verifySize(Y, [360 1], 'Y must be a 360x1 column vector.');
+
+            testCase.verifyEqual(peak_sf, P(6), 'peak_sf must equal sf0 (P(6)).');
+            testCase.verifyEqual(peak_tf, P(7), 'peak_tf must equal tf0 (P(7)).');
+        end
+
+        function testResponseIsHalfPeak(testCase)
+            % Evaluating the tuning function at each contour point should
+            % return exactly half of the peak response.
+
+            P = [10, 0, 0, 0.5, 0.5, 0.1, 4];
+
+            [X, Y] = vis.speed.halfpeakcontour(P);
+
+            % No NaNs expected for a well-behaved symmetric tuning curve.
+            testCase.verifyFalse(any(isnan(X)), 'Unexpected NaN in X for a symmetric curve.');
+            testCase.verifyFalse(any(isnan(Y)), 'Unexpected NaN in Y for a symmetric curve.');
+
+            peak_response = vis.speed.tuningfunc(P(6), P(7), P);
+            half_response = peak_response / 2;
+
+            R_contour = vis.speed.tuningfunc(X(:), Y(:), P);
+
+            testCase.verifyEqual(R_contour, repmat(half_response, 360, 1), ...
+                'AbsTol', 1e-2, 'Response along the contour must be half the peak.');
+        end
+
+        function testSymmetricCaseIsCircleInLogSpace(testCase)
+            % For an isotropic Gaussian (zeta=0, xi=0, sigma_sf=sigma_tf),
+            % the half-peak contour is a circle in log10 space of radius
+            % sigma*sqrt(2*ln2).
+
+            sigma = 0.5;
+            P = [10, 0, 0, sigma, sigma, 0.1, 4];
+
+            [X, Y, peak_sf, peak_tf] = vis.speed.halfpeakcontour(P);
+
+            center = [log10(peak_sf), log10(peak_tf)];
+            log_radius = sqrt((log10(X) - center(1)).^2 + (log10(Y) - center(2)).^2);
+
+            expected_radius = sigma * sqrt(2 * log(2));
+
+            testCase.verifyEqual(log_radius, repmat(expected_radius, 360, 1), ...
+                'AbsTol', 1e-3, 'Symmetric contour must be a circle in log10 space.');
+        end
+
+        function testContourEnclosesPeak(testCase)
+            % The peak response must exceed the response everywhere on the
+            % contour (the contour surrounds the peak).
+
+            P = [8, 0.2, 0.7, 0.6, 0.4, 0.2, 2];
+
+            [X, Y] = vis.speed.halfpeakcontour(P);
+
+            peak_response = vis.speed.tuningfunc(P(6), P(7), P);
+
+            valid = ~isnan(X);
+            R_contour = vis.speed.tuningfunc(X(valid), Y(valid), P);
+
+            testCase.verifyTrue(all(R_contour < peak_response), ...
+                'All contour responses must be below the peak response.');
+        end
+
+        function testSkewedAndSpeedTunedCurve(testCase)
+            % A curve with non-zero skew (zeta) and speed (xi) should still
+            % produce a finite half-peak contour whose responses are half
+            % the peak.
+
+            P = [5, 0.15, 1, 0.5, 0.5, 0.1, 4];
+
+            [X, Y] = vis.speed.halfpeakcontour(P);
+
+            valid = ~isnan(X) & ~isnan(Y);
+            testCase.verifyTrue(all(valid), 'Expected a complete contour for this curve.');
+
+            peak_response = vis.speed.tuningfunc(P(6), P(7), P);
+            half_response = peak_response / 2;
+
+            R_contour = vis.speed.tuningfunc(X, Y, P);
+            testCase.verifyEqual(R_contour, repmat(half_response, 360, 1), ...
+                'AbsTol', 1e-2, 'Response along the skewed contour must be half the peak.');
+        end
+
+        function testCustomRadiusOptions(testCase)
+            % The MaxRadius and RadiusStep options should be accepted and
+            % produce a valid contour.
+
+            P = [10, 0, 0, 0.5, 0.5, 0.1, 4];
+
+            [X, Y] = vis.speed.halfpeakcontour(P, 'MaxRadius', 6, 'RadiusStep', 5e-3);
+
+            testCase.verifySize(X, [360 1], 'X size must remain 360x1.');
+            testCase.verifySize(Y, [360 1], 'Y size must remain 360x1.');
+
+            R_contour = vis.speed.tuningfunc(X, Y, P);
+            half_response = vis.speed.tuningfunc(P(6), P(7), P) / 2;
+            testCase.verifyEqual(R_contour, repmat(half_response, 360, 1), ...
+                'AbsTol', 5e-2, 'Coarser step should still recover the half-peak level.');
+        end
+
+        function testInvalidParameterLength(testCase)
+            % A parameter vector that is not length 7 must error.
+
+            badP = [10, 0, 0, 0.5, 0.5, 0.1]; % only 6 elements
+
+            testCase.verifyError(@() vis.speed.halfpeakcontour(badP), ...
+                'vis:speed:halfpeakcontour:badParameters');
+        end
+
+        function testNonPositivePeakFrequencies(testCase)
+            % Non-positive preferred frequencies must error.
+
+            P = [10, 0, 0, 0.5, 0.5, 0, 4]; % sf0 = 0
+
+            testCase.verifyError(@() vis.speed.halfpeakcontour(P), ...
+                'vis:speed:halfpeakcontour:badPeak');
+        end
+
+    end
+end


### PR DESCRIPTION
## Summary

Adds `vis.speed.halfpeakcontour`, a function that takes a set of speed tuning parameters and returns the X (spatial frequency) and Y (temporal frequency) coordinates of the **half-peak contour** surrounding the preferred frequencies `sf0`/`tf0`.

- Input is the same 7-element parameter vector used by `vis.speed.tuningfunc`: `[A, zeta, xi, sigma_sf, sigma_tf, sf0, tf0]`.
- The peak sits at `(sf0, tf0)`; the peak response is evaluated there and the contour is the locus where the response equals half of that value.
- The contour is sampled with **one point per degree (360 points)** by sweeping rays outward from the peak in `log10(SF)/log10(TF)` space (the space in which the tuning model is naturally symmetric). Crossings are refined by linear interpolation.
- Returns `X` (c/deg) and `Y` (Hz) as 360×1 column vectors of actual coordinate values, ready to plot, plus optional `peak_sf`/`peak_tf` outputs. Rays that never reach half-peak yield `NaN`.
- Options `MaxRadius` and `RadiusStep` control the radial search.

## Tests

Adds `tests/+vis/+speed/test_halfpeakcontour.m` covering:
- Output shape (360×1) and that `peak_sf`/`peak_tf` equal `sf0`/`tf0`.
- Response evaluated at every contour point equals half the peak.
- The isotropic case (`zeta=0, xi=0, sigma_sf=sigma_tf`) forms a circle of radius `sigma·√(2 ln2)` in log space.
- The contour encloses the peak.
- A skewed, speed-tuned curve still yields a complete half-peak contour.
- Custom `MaxRadius`/`RadiusStep` options.
- Input validation (wrong-length `P`, non-positive `sf0`/`tf0`).

https://claude.ai/code/session_01XGGPXqkm9F1FoxaB9QFeoj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGGPXqkm9F1FoxaB9QFeoj)_