### PR TITLE
Grayscale heat map with model half-height contour in speed tuning plot

### DIFF
--- a/+ndi/+calc/+vis/speed_tuning.m
+++ b/+ndi/+calc/+vis/speed_tuning.m
@@ -180,8 +180,9 @@ classdef speed_tuning < ndi.calc.tuning_fit
             end
             vis.speed.plottuning(SF, TF, MNs_fit, 'marker', 'none', 'linestyle', linestyle);
 
-            % now plot raw responses
-            vis.speed.plottuning(SF, TF, MNs);
+            % now plot raw responses; overlay the half-height contour of the
+            % fitted model on the heat map to show the bounds of the model.
+            vis.speed.plottuning(SF, TF, MNs, 'half_contour_params', ft.Priebe_fit_parameters);
 
             ch = get(gcf, 'children');
             currentaxes = gca;

--- a/+vis/+speed/plottuning.m
+++ b/+vis/+speed/plottuning.m
@@ -11,13 +11,23 @@ function plottuning(SF,TF,R,varargin)
 %
 %  This function also takes name/value pairs that modify its
 %  default behavior:
-%  |----------------------------------------------------------------|
-%  |Parameter (default)     | Description                           |
-%  |------------------------|---------------------------------------|
-%  |'marker' ('o')          | Marker type to use in plot            |
-%  |'linestyle' ('none')    | Line style to use                     |
-%  |'do_surf' (1)           | 0/1 Should we do the surface plot?    |
-%  |------------------------|---------------------------------------|
+%  |--------------------------------------------------------------------|
+%  |Parameter (default)         | Description                           |
+%  |----------------------------|---------------------------------------|
+%  |'marker' ('o')              | Marker type to use in plot            |
+%  |'linestyle' ('none')        | Line style to use                     |
+%  |'do_surf' (1)               | 0/1 Should we do the surface plot?    |
+%  |'surf_colormap' (gray(256)) | Colormap for the heat map. The default|
+%  |                            |   ramps from black (low) to white     |
+%  |                            |   (high).                             |
+%  |'half_contour_params' ([])  | If non-empty, a 7-element speed tuning |
+%  |                            |   parameter vector (see               |
+%  |                            |   vis.speed.tuningfunc). The half-peak |
+%  |                            |   (half-height) contour of that model  |
+%  |                            |   is overlaid on the heat map.         |
+%  |'contour_color' ([1 0 0])   | Color of the overlaid half-peak contour|
+%  |'contour_linewidth' (1.5)   | Line width of the overlaid contour     |
+%  |----------------------------|---------------------------------------|
 %
 %  Example:
 %    out = vis.speed.test.responseplay();
@@ -28,6 +38,10 @@ function plottuning(SF,TF,R,varargin)
 marker = 'o';
 linestyle = 'none';
 do_surf = 1;
+surf_colormap = gray(256);
+half_contour_params = [];
+contour_color = [1 0 0];
+contour_linewidth = 1.5;
 vlt.data.assign(varargin{:});
 
 % On the left side
@@ -57,19 +71,65 @@ end;
 
 subplot(1,2,2);
 
-% Use surf
+% Use surf to draw the heat map. The data live in linear SF/TF coordinates
+% but are displayed on log-scaled axes. To keep the flat-shaded coloring
+% aligned with the true coordinates (so that an overlaid contour lines up
+% with the colors), we place the cell *edges* at the geometric midpoints
+% between adjacent SF/TF values in log space. This centers each data point
+% within its colored cell rather than leaving it at a corner.
+sf_edges = local_log_edges(SF(1,:)); % 1 x (n+1) vertex coordinates
+tf_edges = local_log_edges(TF(:,1)); % 1 x (m+1) vertex coordinates
+[SF_surf, TF_surf] = meshgrid(sf_edges, tf_edges); % (m+1) x (n+1) vertices
+
+% Pad the color/height matrix to the vertex grid size. With flat shading,
+% face (i,j) takes its color from C(i,j) = R(i,j); the extra row/column are
+% never used for face color and are present only to match the grid size.
 R_surf = [ R R(:,end) ; R(end,:) R(end,end)];
-SF_surf = [SF SF(:,end)*2; SF(end,:) SF(end,end)*2 ];
-TF_surf = [ TF TF(:,end); TF(end,:)*2 TF(end,end)*2];
+
 surf(SF_surf,TF_surf,R_surf,R_surf);
 set(gca,'View',[0 90]);
 set(gca,'XScale','log','YScale','log');
 set(gca,'XTick',[SF(1,:)]);
 set(gca,'YTick',[TF(:,1)]);
 set(gca,'FontAngle','italic');
-axis([SF_surf(1,1) SF_surf(1,end) TF_surf(1,1) TF_surf(end,1)]);
+axis([sf_edges(1) sf_edges(end) tf_edges(1) tf_edges(end)]);
 shading faceted;
+colormap(gca,surf_colormap);
 
+% Optionally overlay the half-peak (half-height) contour of a fitted model.
+if ~isempty(half_contour_params)
+    [cX, cY, peak_sf, peak_tf] = vis.speed.halfpeakcontour(half_contour_params);
+    cX(end+1) = cX(1); % close the contour loop
+    cY(end+1) = cY(1);
+    z_top = max(R_surf(:)) + 1; % draw above the surface so it is visible
+    hold on;
+    plot3(cX, cY, z_top*ones(size(cX)), '-', ...
+        'Color', contour_color, 'LineWidth', contour_linewidth);
+    plot3(peak_sf, peak_tf, z_top, '+', ...
+        'Color', contour_color, 'LineWidth', contour_linewidth, 'MarkerSize', 8);
+end
 
 xlabel('Spatial frequency (c/deg)','FontAngle','italic');
 ylabel('Temporal frequency (Hz)','FontAngle','italic');
+
+end % plottuning
+
+% -------------------------------------------------------------------------
+
+function edges = local_log_edges(v)
+% LOCAL_LOG_EDGES - compute cell-edge coordinates centered on the values V.
+%
+% Given a monotonic vector V of (positive) coordinate values, returns a
+% vector of length numel(V)+1 whose elements bracket each value at the
+% geometric midpoint (midpoint in log10 space) between neighbors, so that
+% each value sits at the center of its cell.
+    v = v(:).';
+    lv = log10(v);
+    if numel(lv) == 1
+        e = [lv - 0.5, lv + 0.5];
+    else
+        mids = (lv(1:end-1) + lv(2:end)) / 2;
+        e = [lv(1) - (lv(2)-lv(1))/2, mids, lv(end) + (lv(end)-lv(end-1))/2];
+    end
+    edges = 10.^e;
+end % local_log_edges

--- a/tests/+vis/+speed/test_plottuning.m
+++ b/tests/+vis/+speed/test_plottuning.m
@@ -24,5 +24,64 @@ classdef test_plottuning < matlab.unittest.TestCase
             end
 
         end
+
+        function testGrayscaleColormapAndContour(testCase)
+            % Test that plottuning draws a grayscale heat map and overlays
+            % the half-height contour when given model parameters.
+
+            [SF, TF] = meshgrid([0.05 0.1 0.2 0.4], [1 2 4 8]);
+            P = [10, 0, 0, 0.5, 0.5, 0.1, 4];
+            R = vis.speed.tuningfunc(SF, TF, P);
+
+            f = figure('Visible', 'off');
+            cleanup = onCleanup(@() close(f));
+
+            vis.speed.plottuning(SF, TF, R, 'half_contour_params', P);
+
+            % Locate the axes that contains the surface heat map.
+            ax = findobj(f, 'Type', 'axes');
+            surfax = [];
+            for k = 1:numel(ax)
+                if ~isempty(findobj(ax(k), 'Type', 'surface'))
+                    surfax = ax(k);
+                    break;
+                end
+            end
+            testCase.verifyNotEmpty(surfax, 'Expected an axes containing a surface heat map.');
+
+            % The colormap should be grayscale (black to white).
+            testCase.verifyEqual(get(surfax, 'Colormap'), gray(256), 'AbsTol', 1e-12, ...
+                'Heat map colormap should ramp from black to white.');
+
+            % The half-height contour should be drawn as a line on the heat map.
+            contour_lines = findobj(surfax, 'Type', 'line');
+            testCase.verifyNotEmpty(contour_lines, ...
+                'Expected the half-height contour to be overlaid on the heat map.');
+        end
+
+        function testCustomColormap(testCase)
+            % Test that a custom colormap is honored.
+
+            [SF, TF] = meshgrid([0.1 0.2 0.4], [1 2 4]);
+            R = rand(size(SF));
+
+            f = figure('Visible', 'off');
+            cleanup = onCleanup(@() close(f));
+
+            customMap = parula(64);
+            vis.speed.plottuning(SF, TF, R, 'surf_colormap', customMap);
+
+            ax = findobj(f, 'Type', 'axes');
+            surfax = [];
+            for k = 1:numel(ax)
+                if ~isempty(findobj(ax(k), 'Type', 'surface'))
+                    surfax = ax(k);
+                    break;
+                end
+            end
+            testCase.verifyNotEmpty(surfax, 'Expected an axes containing a surface heat map.');
+            testCase.verifyEqual(get(surfax, 'Colormap'), customMap, 'AbsTol', 1e-12, ...
+                'Custom colormap should be applied to the heat map.');
+        end
     end
 end


### PR DESCRIPTION
## Summary

Updates the `ndi.calc.vis.speed_tuning` diagnostic plot (via `vis.speed.plottuning`):

1. **Grayscale heat map** — the response heat map now uses a black→white colormap (`gray`) instead of `parula`. The colormap is configurable via a new `surf_colormap` option.
2. **Model half-height contour overlay** — the half-peak (half-height) contour of the fitted speed tuning model is drawn on top of the heat map, showing the bounds of the model. `speed_tuning.plot` passes the fitted parameters (`ft.Priebe_fit_parameters`) so the model contour is overlaid on the raw-response heat map. A `+` marks the model peak.

## Coordinate alignment

The heat map plots `surf` in true (linear) SF/TF coordinates on log-scaled axes. With flat shading, the previous code padded the grid (extra row/col at 2× the last value), which placed each data point at the **lower-left corner** of its colored cell — a half-cell offset between the colors and the coordinates.

To make the overlaid contour line up with the colors, the surf grid now places cell **edges at the geometric (log-space) midpoints** between adjacent SF/TF values, centering each data point within its colored cell. This aligns the coloring with the true coordinate system that the contour (computed by `vis.speed.halfpeakcontour`) lives in.

## New `plottuning` options

| Option | Default | Description |
|---|---|---|
| `surf_colormap` | `gray(256)` | Heat map colormap (black→white) |
| `half_contour_params` | `[]` | 7-element model parameter vector; if set, overlays its half-height contour |
| `contour_color` | `[1 0 0]` | Contour/peak-marker color |
| `contour_linewidth` | `1.5` | Contour line width |

## Tests

`tests/+vis/+speed/test_plottuning.m` gains tests verifying the grayscale colormap, the contour overlay, and a custom colormap. All tests close their figures via `onCleanup`, so none are left open.

https://claude.ai/code/session_01XGGPXqkm9F1FoxaB9QFeoj

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGGPXqkm9F1FoxaB9QFeoj)_