### PR TITLE
selectRowsByModulationIndex: optionally return F0 and F1 row sets

### DIFF
--- a/+ndi/+viz/selectRowsByModulationIndex.m
+++ b/+ndi/+viz/selectRowsByModulationIndex.m
@@ -1,7 +1,7 @@
-function T_out = selectRowsByModulationIndex(T, NameValueArgs)
+function [T_out, T_F0, T_F1] = selectRowsByModulationIndex(T, NameValueArgs)
 % SELECTROWSBYMODULATIONINDEX - Filter rows based on the modulation index
 %
-%   T_OUT = NDI.VIZ.SELECTROWSBYMODULATIONINDEX(T, NAMEVALUEARGS)
+%   [T_OUT, T_F0, T_F1] = NDI.VIZ.SELECTROWSBYMODULATIONINDEX(T, NAMEVALUEARGS)
 %
 %   Filters a table that has been produced by ndi.viz.modulationIndex.
 %
@@ -15,6 +15,22 @@ function T_out = selectRowsByModulationIndex(T, NameValueArgs)
 %   equal to 'F1'. If the modulation index is less than 1, then the row
 %   is kept in the output table if the row X.properties.response_type is
 %   equal to 'mean'.
+%
+%   OUTPUTS:
+%   T_OUT - The table with the modulation-index-selected rows (F1 for cells
+%           with modulation index >= 1, 'mean' for cells with modulation
+%           index < 1), as described above.
+%   T_F0  - (Optional) The table containing, for every validly-paired cell,
+%           only its 'mean' (F0) row regardless of the modulation index.
+%   T_F1  - (Optional) The table containing, for every validly-paired cell,
+%           only its 'F1' row regardless of the modulation index.
+%
+%   A cell is considered validly paired if its modulation index is not NaN
+%   (ndi.viz.modulationIndex assigns the index to both the 'mean' and 'F1'
+%   rows of each successful pair). T_F0 and T_F1 are useful for analyses that
+%   need to use the F0 or F1 response for every cell rather than the
+%   modulation-index-selected response (for example, to test whether a result
+%   depends on the use of the F1 response for simple cells).
 %
 %   This function can also be specified using name/value pairs.
 %   'modulationIndexColumn'      : The column with the modulation index.
@@ -30,6 +46,7 @@ function T_out = selectRowsByModulationIndex(T, NameValueArgs)
 %
 %   Example:
 %      T_filtered = ndi.viz.selectRowsByModulationIndex(T_with_MI)
+%      [T_filtered, T_F0, T_F1] = ndi.viz.selectRowsByModulationIndex(T_with_MI)
 %
 
 arguments
@@ -70,6 +87,12 @@ if ~NameValueArgs.allowMultipleModulationIndexFilters
 			(MI<1 & strcmpi(response_type,'mean'))  ...
 		);
 	T_out = T(keep_rows,:);
+
+	% Build the F0 ('mean') and F1 row sets for every validly-paired cell.
+	keep_rows_F0 = find(~isnan(MI) & strcmpi(response_type,'mean'));
+	keep_rows_F1 = find(~isnan(MI) & strcmpi(response_type,'F1'));
+	T_F0 = T(keep_rows_F0,:);
+	T_F1 = T(keep_rows_F1,:);
 else
     % multiple filter mode
     if ~isempty(NameValueArgs.modulationIndexColumn)
@@ -81,6 +104,8 @@ else
 
 	modulationIndexColumns = find_column_by_suffix(T, '', '.TC.modulationIndex', 'allow_multiple', true);
     keep_rows = [];
+    keep_rows_F0 = [];
+    keep_rows_F1 = [];
     for i=1:numel(modulationIndexColumns)
         modulationIndexColumn = modulationIndexColumns{i};
         responseTypeColumn = strrep(modulationIndexColumn,'.TC.modulationIndex','.properties.response_type');
@@ -94,8 +119,12 @@ else
                 (MI<1 & strcmpi(response_type,'mean'))  ...
             );
         keep_rows = unique([keep_rows(:); keep_rows_here(:)]);
+        keep_rows_F0 = unique([keep_rows_F0(:); find(~isnan(MI) & strcmpi(response_type,'mean'))]);
+        keep_rows_F1 = unique([keep_rows_F1(:); find(~isnan(MI) & strcmpi(response_type,'F1'))]);
     end
     T_out = T(keep_rows,:);
+    T_F0 = T(keep_rows_F0,:);
+    T_F1 = T(keep_rows_F1,:);
 end
 
 end

--- a/tests/+ndi/+unittest/+viz/testSelectRowsByModulationIndex.m
+++ b/tests/+ndi/+unittest/+viz/testSelectRowsByModulationIndex.m
@@ -1,0 +1,75 @@
+classdef testSelectRowsByModulationIndex < matlab.unittest.TestCase
+% TESTSELECTROWSBYMODULATIONINDEX - Unit tests for ndi.viz.selectRowsByModulationIndex
+%
+% Verifies the modulation-index-based row selection and the optional F0/F1
+% row-set outputs.
+
+    methods (Static)
+        function T = makeTable()
+            % Build a small synthetic table with three cells:
+            %   id 1/2: simple cell  (MI = 1.5, paired mean+F1)
+            %   id 3/4: complex cell (MI = 0.5, paired mean+F1)
+            %   id 5  : unpaired mean row (MI = NaN)
+            id = (1:5)';
+            mi = [1.5; 1.5; 0.5; 0.5; NaN];
+            rt = {'mean'; 'F1'; 'mean'; 'F1'; 'mean'};
+            T = table(id, mi, rt, 'VariableNames', ...
+                {'id', 'x.TC.modulationIndex', 'x.properties.response_type'});
+        end
+    end
+
+    methods (Test)
+
+        function testSelectedRows(testCase)
+            % T_out keeps F1 for simple cells (MI>=1) and mean for complex cells (MI<1),
+            % and excludes unpaired (NaN-MI) rows.
+            T = ndi.unittest.viz.testSelectRowsByModulationIndex.makeTable();
+            T_out = ndi.viz.selectRowsByModulationIndex(T);
+
+            testCase.verifyEqual(height(T_out), 2, ...
+                'Expected one selected row per validly-paired cell.');
+            % id 2 is the simple cell's F1 row; id 3 is the complex cell's mean row.
+            testCase.verifyEqual(sort(T_out.id(:)), [2; 3]);
+        end
+
+        function testF0AndF1RowSets(testCase)
+            % T_F0 and T_F1 contain one row per validly-paired cell, regardless of MI.
+            T = ndi.unittest.viz.testSelectRowsByModulationIndex.makeTable();
+            [T_out, T_F0, T_F1] = ndi.viz.selectRowsByModulationIndex(T);
+
+            % T_F0: the 'mean' rows of the two paired cells (ids 1 and 3), not id 5 (NaN MI).
+            testCase.verifyEqual(sort(T_F0.id(:)), [1; 3]);
+            testCase.verifyTrue(all(strcmpi(T_F0.('x.properties.response_type'), 'mean')));
+
+            % T_F1: the 'F1' rows of the two paired cells (ids 2 and 4).
+            testCase.verifyEqual(sort(T_F1.id(:)), [2; 4]);
+            testCase.verifyTrue(all(strcmpi(T_F1.('x.properties.response_type'), 'F1')));
+
+            % T_out is unchanged by requesting the extra outputs.
+            testCase.verifyEqual(sort(T_out.id(:)), [2; 3]);
+
+            % F0 and F1 sets must be disjoint and exclude the unpaired row.
+            testCase.verifyEmpty(intersect(T_F0.id, T_F1.id));
+            testCase.verifyFalse(ismember(5, T_F0.id));
+        end
+
+        function testSingleFilterMode(testCase)
+            % The single-filter code path produces the same results.
+            T = ndi.unittest.viz.testSelectRowsByModulationIndex.makeTable();
+            [T_out, T_F0, T_F1] = ndi.viz.selectRowsByModulationIndex(T, ...
+                'allowMultipleModulationIndexFilters', false);
+
+            testCase.verifyEqual(sort(T_out.id(:)), [2; 3]);
+            testCase.verifyEqual(sort(T_F0.id(:)), [1; 3]);
+            testCase.verifyEqual(sort(T_F1.id(:)), [2; 4]);
+        end
+
+        function testBackwardCompatibleSingleOutput(testCase)
+            % Single-output callers continue to receive the selected table.
+            T = ndi.unittest.viz.testSelectRowsByModulationIndex.makeTable();
+            T_out = ndi.viz.selectRowsByModulationIndex(T);
+            testCase.verifyEqual(height(T_out), 2);
+        end
+
+    end
+end


### PR DESCRIPTION
## Summary

Adds optional second and third outputs to `ndi.viz.selectRowsByModulationIndex`:

```matlab
[T_out, T_F0, T_F1] = ndi.viz.selectRowsByModulationIndex(T, ...)
```

- `T_out` — unchanged (F1 row for cells with modulation index ≥ 1, `mean`/F0 row for cells with modulation index < 1). **Single-output callers are unaffected.**
- `T_F0` — for every validly-paired cell (non-NaN modulation index), only its `mean` (F0) row.
- `T_F1` — for every validly-paired cell, only its `F1` row.

This enables analyses that need the F0 or F1 response for *every* cell rather than the modulation-index-selected response — for example, testing whether a result depends on using the F1 response for simple cells. Both the single- and multiple-modulation-index-filter code paths are handled.

## Tests

Adds `tests/+ndi/+unittest/+viz/testSelectRowsByModulationIndex.m`, which uses a small synthetic table (a simple cell, a complex cell, and an unpaired NaN-MI row) to verify:
- modulation-index selection in `T_out`,
- the new `T_F0`/`T_F1` row sets (one mean/F1 row per paired cell, NaN-MI rows excluded, disjoint),
- the single-filter code path,
- single-output backward compatibility.

Runs in the existing CI test suite.

> Note: not yet run on a live MATLAB interpreter from the authoring environment; first real run will be in CI.

https://claude.ai/code/session_01CmhbjoYN2qpYqMyHFtmhf3

---
_Generated by [Claude Code](https://claude.ai/code/session_01CmhbjoYN2qpYqMyHFtmhf3)_